### PR TITLE
(chore) - schedule 페이지 layout 구분

### DIFF
--- a/src/components/SchedulePage/Schedule_Banner.jsx
+++ b/src/components/SchedulePage/Schedule_Banner.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import "../../style/Schedule_Banner.css";
+
+function Schedule_Banner() {
+  return (
+    <>
+      <div className="Schedule_Frame_Banner">
+        <div className="Schedule_Frame_Banner_Icons">
+          공항기본 정보 ICON Components
+        </div>
+        <div className="Schedule_Frame_Banner_infoWeather">
+          <div className="currentTime">현재시각</div>
+          <div className="intervalTime">시차</div>
+          <div className="weather">날씨</div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default Schedule_Banner;

--- a/src/components/SchedulePage/Schedule_Frame.jsx
+++ b/src/components/SchedulePage/Schedule_Frame.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import Schedule_Header from "./Schedule_Header";
+import Schedule_Banner from "./Schedule_Banner";
+import Schedule_Grid_Green from "./Schedule_Grid_Green";
+import Schedule_Grid_Black from "./Schedule_Grid_Black";
+
+// 반응형 요소들은 각 부분에 해당하는 파일에 넣어 주세요!
+function Schedule_Frame() {
+  return (
+    <div>
+      <Schedule_Header />
+      <Schedule_Banner />
+      <Schedule_Grid_Green />
+      <Schedule_Grid_Black />
+    </div>
+  );
+}
+
+export default Schedule_Frame;

--- a/src/components/SchedulePage/Schedule_Grid_Black.jsx
+++ b/src/components/SchedulePage/Schedule_Grid_Black.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+import "../../style/Schedule_Grid_Black.css";
+
+function Schedule_Grid_Black() {
+  return (
+    <>
+      <div className="Schedule_Frame_Grid2">
+        <div className="Schedule_Frame_Grid2_recommend">
+          추천 정보(프로모션/전시회) components
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default Schedule_Grid_Black;

--- a/src/components/SchedulePage/Schedule_Grid_Green.jsx
+++ b/src/components/SchedulePage/Schedule_Grid_Green.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import "../../style/Schedule_Frame.css";
+import upArrow from "../../img/inairport_grid_UpArrow.png";
+
+function Schedule_Grid_Green() {
+  const scrollTorecommend = () => {
+    // window.scroll({
+    //   top: 0,
+    //   behavior: "smooth",
+    // });
+    window.scrollTo({ top: 1299, behavior: "smooth" });
+  };
+  return (
+    <>
+      <div className="Schedule_Frame_Grid1" id="recommend_Grid1">
+        <div className="Schedule_Frame_Grid1_title">
+          EXPERIENCE IN AIRPORT
+          <hr />
+        </div>
+        <div className="Schedule_Frame_Grid1_recommend">
+          추천 정보(시설/휴식/식사/면세) components
+        </div>
+        <div className="Schedule_Frame_Grid1_Arrow">
+          <img className="Uparrow" src={upArrow} alt="화살표"></img>
+        </div>
+        <div className="Schedule_Frame_Grid1_Btn" onClick={scrollTorecommend}>
+          공항 속 새로운 경험하러가기
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default Schedule_Grid_Green;

--- a/src/components/SchedulePage/Schedule_Header.jsx
+++ b/src/components/SchedulePage/Schedule_Header.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import "../../style/Schedule_Header.css";
+import ToggleBtn from "./Changing/ToggleBtn";
+
+function Schedule_Header() {
+  return (
+    <>
+      <div className="Schedule_Frame_Header">
+        <div className="Schedule_Frame_Header_btn">
+          <ToggleBtn />
+        </div>
+        <div className="Schedule_Frame_Header_text">
+          <div className="text1">one of the best airports in the world</div>
+          <div className="text2">SINGAPORE CHANGI AIRPORT</div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default Schedule_Header;

--- a/src/style/Schedule_Banner.css
+++ b/src/style/Schedule_Banner.css
@@ -1,0 +1,80 @@
+/*Font 사용*/
+@font-face {
+  font-family: "EsaManru";
+  font-weight: 300;
+  font-style: normal;
+  src: url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.eot");
+  src: url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.eot?#iefix")
+      format("embedded-opentype"),
+    url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.woff2")
+      format("woff2"),
+    url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.woff")
+      format("woff"),
+    url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.ttf")
+      format("truetype");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Plaid";
+  font-weight: 300;
+  font-style: normal;
+  src: url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf");
+  src: url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf")
+      format("embedded-opentype"),
+    url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf") format("woff2"),
+    url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf") format("woff"),
+    url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf") format("truetype");
+
+  font-display: swap;
+}
+
+/*Banner 부분*/
+.Schedule_Frame_Banner {
+  position: relative;
+  height: 780px;
+  background-image: url("../img/inairport_banner.png");
+  background-size: cover;
+  color: white;
+}
+
+/*공항 Icon - Banner 부분*/
+.Schedule_Frame_Banner_Icons {
+  border: 1px solid red;
+  position: absolute;
+  top: 40%;
+  left: 80px;
+
+  width: 314px;
+  height: 37px;
+
+  background-color: rgba(165, 165, 165, 0.5);
+}
+
+/*시간, 날씨 정보 - Banner 부분*/
+.Schedule_Frame_Banner_infoWeather {
+  position: absolute;
+  top: 40%;
+  right: 80px;
+
+  width: 314px;
+  height: 41px;
+
+  background-color: rgba(165, 165, 165, 0.5);
+  line-height: 41px;
+  text-align: center;
+
+  /*infoweather안의 요소들의 위치(width % 비율 조정)*/
+  display: flex;
+  .currentTime {
+    width: 50%;
+  }
+  .intervalTime {
+    border-left: 1px solid white;
+    width: 30%;
+  }
+  .weather {
+    border-left: 1px solid white;
+    width: 20%;
+  }
+}

--- a/src/style/Schedule_Frame.css
+++ b/src/style/Schedule_Frame.css
@@ -1,0 +1,216 @@
+/*Font 사용*/
+@font-face {
+  font-family: "EsaManru";
+  font-weight: 300;
+  font-style: normal;
+  src: url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.eot");
+  src: url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.eot?#iefix")
+      format("embedded-opentype"),
+    url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.woff2")
+      format("woff2"),
+    url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.woff")
+      format("woff"),
+    url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.ttf")
+      format("truetype");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Plaid";
+  font-weight: 300;
+  font-style: normal;
+  src: url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf");
+  src: url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf")
+      format("embedded-opentype"),
+    url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf") format("woff2"),
+    url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf") format("woff"),
+    url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf") format("truetype");
+
+  font-display: swap;
+}
+
+/*Header 부분 */
+.Schedule_Frame_Header {
+  position: relative;
+  height: 439px;
+
+  text-align: center;
+  background-color: rgba(244, 240, 231, 1);
+  color: rgba(44, 110, 73, 1);
+}
+
+/*(공항in/out) 스위치, 컴포넌트 */
+.Schedule_Frame_Header_btn {
+  position: absolute;
+  top: 15%;
+  left: 50%;
+  transform: translate(-50%);
+
+  border: 1px solid red;
+}
+
+.Schedule_Frame_Header_text {
+  position: absolute;
+  top: 30%;
+  left: 50%;
+  transform: translate(-50%);
+
+  .text1 {
+    /* border: 1px solid blue; */
+    font-family: "EsaManru";
+    font-size: 19px;
+    line-height: 70px;
+    font-weight: 300;
+  }
+
+  .text2 {
+    /* border: 1px solid blue; */
+    font-family: "EsaManru";
+    font-size: 75px;
+    line-height: 92px;
+    font-weight: 300;
+  }
+}
+
+/*Banner 부분*/
+.Schedule_Frame_Banner {
+  position: relative;
+  height: 780px;
+  background-image: url("../img/inairport_banner.png");
+  background-size: cover;
+  color: white;
+}
+
+/*공항 Icon - Banner 부분*/
+.Schedule_Frame_Banner_Icons {
+  border: 1px solid red;
+  position: absolute;
+  top: 40%;
+  left: 80px;
+
+  width: 314px;
+  height: 37px;
+
+  background-color: rgba(165, 165, 165, 0.5);
+}
+
+/*시간, 날씨 정보 - Banner 부분*/
+.Schedule_Frame_Banner_infoWeather {
+  position: absolute;
+  top: 40%;
+  right: 80px;
+
+  width: 314px;
+  height: 41px;
+
+  background-color: rgba(165, 165, 165, 0.5);
+  line-height: 41px;
+  text-align: center;
+
+  /*infoweather안의 요소들의 위치(width % 비율 조정)*/
+  display: flex;
+  .currentTime {
+    width: 50%;
+  }
+  .intervalTime {
+    border-left: 1px solid white;
+    width: 30%;
+  }
+  .weather {
+    border-left: 1px solid white;
+    width: 20%;
+  }
+}
+
+/*Grid1  부분*/
+.Schedule_Frame_Grid1 {
+  position: relative;
+  height: 1712px;
+  background-color: rgba(44, 110, 73, 1);
+}
+
+.Schedule_Frame_Grid1_title {
+  height: 166px;
+
+  padding-left: 102px;
+  padding-right: 102px;
+  padding-top: 72px;
+
+  color: rgba(255, 255, 255, 1);
+
+  font-family: "EsaManru";
+  font-size: 98px;
+  line-height: 45px;
+  font-weight: 300;
+
+  text-align: center;
+}
+
+/*추천 정보(시설/휴식/식사/면세) components - Grid1 부분*/
+.Schedule_Frame_Grid1_recommend {
+  border: 3px solid red;
+  height: 1200px;
+  color: white;
+  line-height: 1200px;
+  text-align: center;
+}
+
+.Schedule_Frame_Grid1_Arrow {
+  position: absolute;
+  bottom: 12%;
+  left: 50%;
+  transform: translate(-50%);
+
+  height: 20px;
+  .Uparrow {
+    width: 32px;
+    animation: motion 0.4s linear 0s infinite alternate;
+  }
+}
+
+@keyframes motion {
+  0% {
+    padding-top: 10px;
+  }
+  100% {
+    padding-top: 0px;
+  }
+}
+
+.Schedule_Frame_Grid1_Btn {
+  border: 1px solid rgba(0, 0, 0, 1);
+  border-radius: 5px;
+
+  position: absolute;
+  bottom: 5%;
+  left: 50%;
+  transform: translate(-50%);
+
+  height: 46px;
+  width: 419px;
+
+  background-color: rgba(0, 0, 0, 1);
+  color: rgba(244, 240, 231, 1);
+
+  /*btn text 중앙 정렬(부모 tag의 높이와 같게 설정)*/
+  line-height: 46px;
+  text-align: center;
+
+  font-family: "EsaManru";
+  font-size: 20px;
+}
+
+.Schedule_Frame_Grid1_Btn:hover {
+  background-color: rgba(44, 110, 73, 1);
+  color: rgba(0, 0, 0, 1);
+}
+
+/*Grid 2 - (기획전, 이벤트 소개)*/
+.Schedule_Frame_Grid2 {
+  border: 3px solid red;
+  height: 700px;
+  line-height: 700px;
+  text-align: center;
+  background-color: rgba(25, 25, 25, 1);
+  color: white;
+}

--- a/src/style/Schedule_Grid_Black.css
+++ b/src/style/Schedule_Grid_Black.css
@@ -1,0 +1,40 @@
+/*Font 사용*/
+@font-face {
+  font-family: "EsaManru";
+  font-weight: 300;
+  font-style: normal;
+  src: url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.eot");
+  src: url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.eot?#iefix")
+      format("embedded-opentype"),
+    url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.woff2")
+      format("woff2"),
+    url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.woff")
+      format("woff"),
+    url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.ttf")
+      format("truetype");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Plaid";
+  font-weight: 300;
+  font-style: normal;
+  src: url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf");
+  src: url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf")
+      format("embedded-opentype"),
+    url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf") format("woff2"),
+    url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf") format("woff"),
+    url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf") format("truetype");
+
+  font-display: swap;
+}
+
+/*Grid 2 - (기획전, 이벤트 소개)*/
+.Schedule_Frame_Grid2 {
+  border: 3px solid red;
+  height: 700px;
+  line-height: 700px;
+  text-align: center;
+  background-color: rgba(25, 25, 25, 1);
+  color: white;
+}

--- a/src/style/Schedule_Grid_Green.css
+++ b/src/style/Schedule_Grid_Green.css
@@ -1,0 +1,113 @@
+/*Font 사용*/
+@font-face {
+  font-family: "EsaManru";
+  font-weight: 300;
+  font-style: normal;
+  src: url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.eot");
+  src: url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.eot?#iefix")
+      format("embedded-opentype"),
+    url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.woff2")
+      format("woff2"),
+    url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.woff")
+      format("woff"),
+    url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.ttf")
+      format("truetype");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Plaid";
+  font-weight: 300;
+  font-style: normal;
+  src: url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf");
+  src: url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf")
+      format("embedded-opentype"),
+    url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf") format("woff2"),
+    url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf") format("woff"),
+    url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf") format("truetype");
+
+  font-display: swap;
+}
+
+/*Grid_Green  부분*/
+.Schedule_Frame_Grid1 {
+  position: relative;
+  height: 1712px;
+  background-color: rgba(44, 110, 73, 1);
+}
+
+.Schedule_Frame_Grid1_title {
+  height: 166px;
+
+  padding-left: 102px;
+  padding-right: 102px;
+  padding-top: 72px;
+
+  color: rgba(255, 255, 255, 1);
+
+  font-family: "EsaManru";
+  font-size: 98px;
+  line-height: 45px;
+  font-weight: 300;
+
+  text-align: center;
+}
+
+/*추천 정보(시설/휴식/식사/면세) components - Grid1 부분*/
+.Schedule_Frame_Grid1_recommend {
+  border: 3px solid red;
+  height: 1200px;
+  color: white;
+  line-height: 1200px;
+  text-align: center;
+}
+
+.Schedule_Frame_Grid1_Arrow {
+  position: absolute;
+  bottom: 12%;
+  left: 50%;
+  transform: translate(-50%);
+
+  height: 20px;
+  .Uparrow {
+    width: 32px;
+    animation: motion 0.4s linear 0s infinite alternate;
+  }
+}
+
+@keyframes motion {
+  0% {
+    padding-top: 10px;
+  }
+  100% {
+    padding-top: 0px;
+  }
+}
+
+.Schedule_Frame_Grid1_Btn {
+  border: 1px solid rgba(0, 0, 0, 1);
+  border-radius: 5px;
+
+  position: absolute;
+  bottom: 5%;
+  left: 50%;
+  transform: translate(-50%);
+
+  height: 46px;
+  width: 419px;
+
+  background-color: rgba(0, 0, 0, 1);
+  color: rgba(244, 240, 231, 1);
+
+  /*btn text 중앙 정렬(부모 tag의 높이와 같게 설정)*/
+  line-height: 46px;
+  text-align: center;
+
+  font-family: "EsaManru";
+  font-size: 20px;
+}
+
+.Schedule_Frame_Grid1_Btn:hover {
+  background-color: rgba(44, 110, 73, 1);
+  color: rgba(0, 0, 0, 1);
+}

--- a/src/style/Schedule_Header.css
+++ b/src/style/Schedule_Header.css
@@ -1,0 +1,73 @@
+/*Font 사용*/
+@font-face {
+  font-family: "EsaManru";
+  font-weight: 300;
+  font-style: normal;
+  src: url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.eot");
+  src: url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.eot?#iefix")
+      format("embedded-opentype"),
+    url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.woff2")
+      format("woff2"),
+    url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.woff")
+      format("woff"),
+    url("https://cdn.jsdelivr.net/gh/webfontworld/gonggames/EsaManruLight.ttf")
+      format("truetype");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Plaid";
+  font-weight: 300;
+  font-style: normal;
+  src: url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf");
+  src: url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf")
+      format("embedded-opentype"),
+    url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf") format("woff2"),
+    url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf") format("woff"),
+    url("../font/Plaid_FaktPro/Plaid-normal-400-100.ttf") format("truetype");
+
+  font-display: swap;
+}
+
+/*Header 부분 */
+.Schedule_Frame_Header {
+  position: relative;
+  height: 439px;
+
+  text-align: center;
+  background-color: rgba(244, 240, 231, 1);
+  color: rgba(44, 110, 73, 1);
+}
+
+/*(공항in/out) 스위치, 컴포넌트 */
+.Schedule_Frame_Header_btn {
+  position: absolute;
+  top: 15%;
+  left: 50%;
+  transform: translate(-50%);
+
+  border: 1px solid red;
+}
+
+.Schedule_Frame_Header_text {
+  position: absolute;
+  top: 30%;
+  left: 50%;
+  transform: translate(-50%);
+
+  .text1 {
+    /* border: 1px solid blue; */
+    font-family: "EsaManru";
+    font-size: 19px;
+    line-height: 70px;
+    font-weight: 300;
+  }
+
+  .text2 {
+    /* border: 1px solid blue; */
+    font-family: "EsaManru";
+    font-size: 75px;
+    line-height: 92px;
+    font-weight: 300;
+  }
+}


### PR DESCRIPTION
기존 inAirport에 있는 Schedule 페이지 코드 layout별로 file 나누어 두었습니다. 

- Schedule_Header.jsx / 토글 스위치 
- Schedule_Banner.jsx / 공항 아이콘, 시간/날씨 정보 
- Schedule_Grid_Green.jsx / Grid 상단부분(녹색 바탕), <추천 정보1 >   
- Schedule_Grid_Black.jsx / Grid 하단부분(검정색 바탕), <추천 정보2>  
- Schedule_Frame.jsx  / Schedule(페이지 테스트 해보기 위한 file) 
